### PR TITLE
add LinearAlgebra

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
 Compat = "3.13"


### PR DESCRIPTION
This should fix 
```
[ Info: Precompiling Expectations [2fe49d83-0758-5602-8f54-1f90ad0d522b]
┌ Warning: Package Expectations does not have LinearAlgebra in its dependencies:
│ - If you have Expectations checked out for development and have
│   added LinearAlgebra as a dependency but haven't updated your primary
│   environment's manifest file, try `Pkg.resolve()`.
│ - Otherwise you may need to report an issue with Expectations
└ Loading LinearAlgebra into Expectations from project dependency, future warnings for Expectations are suppressed.
```
but I just did the change on the web editor and did not test.