### PR TITLE
Add explicit guide for truncated distributions

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -112,6 +112,15 @@ Here is a list of currently supported distributions, along with keyword argument
 | Gamma <: ... | Gauss-Laguerre (...) | n = 32 | ... |
 | Univariate | Trapezoidal <: ExplicitQuadratureAlgorithm | N/A | All nodes must be inside distribution's support. |
 
+###
+
+Some unbounded distributions are currently not supported (e.g., Poisson). Depending on your use case truncating may be a feasible option:
+```@repl
+E = expectation(Pareto()) # Throws error
+E = expectation(truncated(Pareto(),0.0,1000.0)) # Truncated Pareto on [0,1000]
+```
+See `Distributions.truncated` for more. Of course, truncating the distribution also affects its properties.
+
 ## Mathematical Details and References
 
 The specific quadrature algorithms come from the [`FastGaussQuadrature.jl`](https://github.com/ajt60gaibb/FastGaussQuadrature.jl) library, which is maintained by [Alex Townsend](https://github.com/ajt60gaibb) of Cornell University. Much of the quadrature code came from the [`DistQuads.jl`](https://github.com/pkofod/DistQuads.jl) library, which is maintained by [Patrick K. Mogensen](https://github.com/pkofod) at the University of Copenhagen. In addition, there are some objects contributed by individual users; see docstring for citations.

--- a/src/iterable.jl
+++ b/src/iterable.jl
@@ -1,4 +1,4 @@
-#= 
+#=
     All iterable expectations. =#
 
 # Callable behavior for the object. Parameters because we cannot add methods to an abstract type.
@@ -53,7 +53,7 @@ Implements left-multiplication of an `IterableExpectation` by a real scalar.
 *(r::Real, e::IterableExpectation) =  IterableExpectation(nodes(e), r * weights(e)) # Necessary because, for example, multiplying UnitRange * 2 = StepRange
 
 
-#= 
+#=
     Discrete iterable expectations. =#
 
 # Constructors for the object.
@@ -77,7 +77,7 @@ function _expectation(dist::DiscreteUnivariateDistribution, alg::Type{FiniteDisc
     return IterableExpectation(ourSupport, ourWeights);
 end
 
-#= 
+#=
     Continuous iterable expectations (no nodes supplied.) =#
 
 # General catchall behavior --> Gauss-Legendre quadrature.
@@ -96,7 +96,7 @@ Implements Gauss-Legendre quadrature for continuous univariate distributions for
 function _expectation(dist::ContinuousUnivariateDistribution, alg::Type{Gaussian}; n=500, kwargs...)
     a = minimum(dist)
     b = maximum(dist)
-    (a > -Inf && b < Inf) || throw(ArgumentError("The distribution must be defined on a compact interval."))
+    (a > -Inf && b < Inf) || throw(ArgumentError("The distribution must be defined on a compact interval. If applicable, bound the distribution by truncating, e.g., expectation(truncated(Pareto(),0.0,1000.0)"))
     rawNodes, rawWeights = gausslegendre(n)
     # Transform nodes to proper interval.
     nodes = map(x -> (0.5(b - a)) * x + (a + b) / 2, rawNodes)
@@ -240,7 +240,7 @@ function _expectation(dist::Chisq, alg::Type{Gaussian}; n=32, kwargs...)
     return IterableExpectation(nodes, weights)
 end
 
-#= 
+#=
     Continuous iterable distributions (nodes supplied.) =#
 
 # Dispatcher.
@@ -286,7 +286,7 @@ Overloads trapezoidal integration for cases where the user-defined grids are reg
     return IterableExpectation(nodes, allWeights)
 end
 
-#= 
+#=
     Convenience functions. =#
 """
     expectation(f::Function, dist::DiscreteUnivariateDistribution, alg::Type{FiniteDiscrete} = FiniteDiscrete; kwargs...) = expectation(dist, alg; kwargs...)(f)

--- a/test/iterable.jl
+++ b/test/iterable.jl
@@ -128,3 +128,12 @@ for dist in distset
     @test weights(2E) ≈ 2*weights(E) # Left-multiplying.
     @test 3E*z ≈ (3E) * z ≈ 3*(E * z) # Linearity.
 end
+
+## Truncated distrubtions
+@test_throws ArgumentError E = expectation(Pareto())
+# Mean of pareto is (α * θ / (α - 1)). If we bound a Pareto at a high number we should get (close to) the analytical mean
+α = 5.0
+θ = 1.0
+righttrunc = 10000
+E = expectation(truncated(Pareto(α,θ),nothing,righttrunc),n=1000) # Right truncated Pareto at 1000
+@test E(x->x) ≈ α*θ/(α-1)


### PR DESCRIPTION
It wasn't obvious that I could truncate the distributions so I added that to the documentation, to the `ArgumentError`, and a test.

Somewhat related to #40